### PR TITLE
Quest api

### DIFF
--- a/ravenloft/serializers.py
+++ b/ravenloft/serializers.py
@@ -1,5 +1,19 @@
 from rest_framework import serializers
-from ravenloft.models import Domain
+from ravenloft.models import Domain, Quest
+
+
+class DisplayChoiceField(serializers.ChoiceField):
+    def __init__(self, choices, **kwargs):
+        super().__init__(choices=choices, **kwargs)
+
+    def to_representation(self, value):
+        return self.choices[value]
+
+    def to_internal_value(self, data):
+        reverse_choices = {v: k for k, v in self.choices.items()}
+        if data in reverse_choices:
+            return reverse_choices[data]
+        return super().to_internal_value(data)
 
 
 class DomainSerializer(serializers.ModelSerializer):
@@ -13,3 +27,55 @@ class DomainSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at"
         ]
+
+
+class QuestSerializer(serializers.ModelSerializer):
+    status = DisplayChoiceField(choices=Quest.Status.choices, required=False)
+
+    class Meta:
+        model = Quest
+        fields = [
+            "id",
+            "name",
+            "created_at",
+            "day_completed",
+            "day_given",
+            "given_by",
+            "notes",
+            "objective",
+            "reward",
+            "status",
+            "time_sensitive",
+            "updated_at"
+        ]
+
+    def validate_day_completed(self, value):
+        data = self.initial_data
+        day_completed = value
+        day_given = data.get("day_given")
+        day_given = int(day_given) if day_given else None
+
+        if day_given is None and Quest.objects.exists():
+            quest = Quest.objects.get()
+            day_given = quest.day_given
+
+        if day_completed and day_given and day_completed < day_given:
+            raise serializers.ValidationError(
+                "day_completed cannot be before day_given."
+            )
+
+    def validate_day_given(self, value):
+        data = self.initial_data
+        day_given = value
+        day_completed = data.get("day_completed")
+        day_completed = int(day_given) if day_completed else None
+
+        if day_completed is None and Quest.objects.exists():
+            quest = Quest.objects.get()
+            day_completed = quest.day_completed
+
+        if day_completed and day_given and day_completed < day_given:
+            raise serializers.ValidationError(
+                "day_given cannot be after day_completed."
+            )
+        return value

--- a/ravenloft/tests/api_requests/domains/test_delete_domain.py
+++ b/ravenloft/tests/api_requests/domains/test_delete_domain.py
@@ -1,11 +1,11 @@
 import pytest
-from ravenloft.models import Domain
 from rest_framework.test import APIClient
+from ravenloft.tests.factories.domain_factory import DomainFactory
 
 
 @pytest.mark.django_db
 def test_delete_domain():
-    domain = Domain.objects.create(name="Lamordia")
+    domain = DomainFactory()
     client = APIClient()
     response = client.delete(f"/domains/{domain.id}/")
 

--- a/ravenloft/tests/api_requests/domains/test_get_domain.py
+++ b/ravenloft/tests/api_requests/domains/test_get_domain.py
@@ -1,25 +1,21 @@
 import pytest
 from django.utils import dateparse
-from ravenloft.models import Domain
 from rest_framework.test import APIClient
+from ravenloft.tests.factories.domain_factory import DomainFactory
 
 
 @pytest.mark.django_db
 def test_get_domain():
-    domain = Domain.objects.create(
-        name="Lamordia",
-        domain_lord="Someone",
-        notes="spooky"
-    )
+    domain = DomainFactory()
     client = APIClient()
     response = client.get(f"/domains/{domain.id}/")
     updated_at = dateparse.parse_datetime(response.data["updated_at"])
 
     assert response.status_code == 200
     assert response.data["id"] == domain.id
-    assert response.data["name"] == "Lamordia"
-    assert response.data["domain_lord"] == "Someone"
-    assert response.data["notes"] == "spooky"
+    assert response.data["name"] == domain.name
+    assert response.data["domain_lord"] == domain.domain_lord
+    assert response.data["notes"] == domain.notes
     assert updated_at == domain.updated_at
 
 

--- a/ravenloft/tests/api_requests/domains/test_get_domains.py
+++ b/ravenloft/tests/api_requests/domains/test_get_domains.py
@@ -1,12 +1,12 @@
 import pytest
-from ravenloft.models import Domain
 from rest_framework.test import APIClient
+from ravenloft.tests.factories.domain_factory import DomainFactory
 
 
 @pytest.mark.django_db
 def test_get_all_domains():
-    Domain.objects.create(name="Lamordia")
-    Domain.objects.create(name="Barovia")
+    DomainFactory(name="Lamordia")
+    DomainFactory(name="Barovia")
 
     client = APIClient()
     response = client.get("/domains/")

--- a/ravenloft/tests/api_requests/domains/test_update_domain.py
+++ b/ravenloft/tests/api_requests/domains/test_update_domain.py
@@ -1,29 +1,23 @@
 import pytest
 from django.utils import dateparse
-from ravenloft.models import Domain
 from rest_framework.test import APIClient
+from ravenloft.tests.factories.domain_factory import DomainFactory
 
 
 @pytest.mark.django_db
 def test_update_domain():
-    domain = Domain.objects.create(
-        name="Lamordia",
-        domain_lord="Someone",
-        notes="spooky"
-    )
-    original_updated_at = domain.updated_at
-
+    domain = DomainFactory(domain_lord="Someone", notes="spooky")
     client = APIClient()
     body = {
         "domain_lord": "Viktra Mordenheim",
         "notes": "Lookout for radiation in the forest"
     }
+    original_updated_at = domain.updated_at
     response = client.patch(f"/domains/{domain.id}/", body)
     updated_at = dateparse.parse_datetime(response.data["updated_at"])
 
     assert response.status_code == 200
     assert response.data["id"] == domain.id
-    assert response.data["name"] == "Lamordia"
     assert response.data["domain_lord"] == "Viktra Mordenheim"
     assert response.data["notes"] == "Lookout for radiation in the forest"
     assert updated_at > original_updated_at

--- a/ravenloft/tests/api_requests/quests/test_create_quest.py
+++ b/ravenloft/tests/api_requests/quests/test_create_quest.py
@@ -1,0 +1,129 @@
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_create_quest():
+    client = APIClient()
+    url = "/quests/"
+    data = {
+        "name": "Haunted Hotel",
+        "day_given": 2,
+        "given_by": "Ruby (owner)",
+        "notes": "Shannon thinks it's ghosts. Guests disappeared from room 237.",
+        "objective": "Find out what's been terrorizing hotel guests",
+        "reward": "200 gold"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["id"] is not None
+    assert response.data["name"] == data["name"]
+    assert response.data["created_at"] is not None
+    assert response.data["day_completed"] is None
+    assert response.data["day_given"] == data["day_given"]
+    assert response.data["notes"] == data["notes"]
+    assert response.data["objective"] == data["objective"]
+    assert response.data["reward"] == data["reward"]
+    assert response.data["status"] == "Not Started"
+    assert response.data["time_sensitive"] is False
+    assert response.data["updated_at"] is not None
+
+
+@pytest.mark.django_db
+def test_default_values():
+    client = APIClient()
+    url = "/quests/"
+    data = {
+        "name": "Haunted Hotel",
+        "day_given": 2,
+        "given_by": "Ruby (owner)",
+        "objective": "Find out what's been terrorizing hotel guests",
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["day_completed"] is None
+    assert response.data["notes"] == ""
+    assert response.data["objective"] == data["objective"]
+    assert response.data["reward"] == ""
+    assert response.data["status"] == "Not Started"
+    assert response.data["time_sensitive"] is False
+
+
+@pytest.mark.django_db
+def test_invalid_day_completed():
+    client = APIClient()
+    url = "/quests/"
+    data = {
+        "name": "Haunted Hotel",
+        "day_completed": 1,
+        "day_given": 2,
+        "given_by": "Ruby (owner)",
+        "objective": "Find out what's been terrorizing hotel guests"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "day_completed"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == "day_completed cannot be before day_given."
+
+
+@pytest.mark.django_db
+def test_valid_day_completed():
+    client = APIClient()
+    url = "/quests/"
+    data = {
+        "name": "Haunted Hotel",
+        "day_completed": 5,
+        "day_given": 2,
+        "given_by": "Ruby (owner)",
+        "objective": "Find out what's been terrorizing hotel guests"
+    }
+    response = client.post(url, data)
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db
+def test_invalid_status():
+    client = APIClient()
+    url = "/quests/"
+    data = {
+        "name": "Haunted Hotel",
+        "day_given": 2,
+        "given_by": "Ruby (owner)",
+        "objective": "Find out what's been terrorizing hotel guests",
+        "status": "Invalid Option"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "status"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == '"Invalid Option" is not a valid choice.'
+
+
+@pytest.mark.django_db
+def test_valid_status():
+    client = APIClient()
+    url = "/quests/"
+    data = {
+        "name": "Haunted Hotel",
+        "day_given": 2,
+        "given_by": "Ruby (owner)",
+        "objective": "Find out what's been terrorizing hotel guests",
+        "status": "Paused"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["status"] == "Paused"

--- a/ravenloft/tests/api_requests/quests/test_delete_quest.py
+++ b/ravenloft/tests/api_requests/quests/test_delete_quest.py
@@ -1,0 +1,24 @@
+import pytest
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.quest_factory import QuestFactory
+
+
+@pytest.mark.django_db
+def test_delete_quest():
+    quest = QuestFactory()
+    client = APIClient()
+    response = client.delete(f"/quests/{quest.id}/")
+
+    assert response.status_code == 204
+
+
+@pytest.mark.django_db
+def test_invalid_quest_id():
+    client = APIClient()
+    response = client.delete("/quests/0/")
+
+    assert response.status_code == 404
+    assert response.data["title"] == "Not Found"
+
+    error = response.data["errors"][0]
+    assert error["detail"] == "No Quest matches the given query."

--- a/ravenloft/tests/api_requests/quests/test_get_quest.py
+++ b/ravenloft/tests/api_requests/quests/test_get_quest.py
@@ -1,0 +1,38 @@
+import pytest
+from django.utils import dateparse
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.quest_factory import QuestFactory
+
+
+@pytest.mark.django_db
+def test_get_quest():
+    quest = QuestFactory()
+    client = APIClient()
+    response = client.get(f"/quests/{quest.id}/")
+    created_at = dateparse.parse_datetime(response.data["created_at"])
+    updated_at = dateparse.parse_datetime(response.data["updated_at"])
+
+    assert response.status_code == 200
+    assert response.data["id"] == quest.id
+    assert response.data["name"] == quest.name
+    assert created_at == quest.created_at
+    assert response.data["day_completed"] == quest.day_completed
+    assert response.data["day_given"] == quest.day_given
+    assert response.data["notes"] == quest.notes
+    assert response.data["objective"] == quest.objective
+    assert response.data["reward"] == quest.reward
+    assert response.data["status"] == quest.get_status_display()
+    assert response.data["time_sensitive"] == quest.time_sensitive
+    assert updated_at == quest.updated_at
+
+
+@pytest.mark.django_db
+def test_invalid_quest_id():
+    client = APIClient()
+    response = client.get("/quests/0/")
+
+    assert response.status_code == 404
+    assert response.data["title"] == "Not Found"
+
+    error = response.data["errors"][0]
+    assert error["detail"] == "No Quest matches the given query."

--- a/ravenloft/tests/api_requests/quests/test_get_quests.py
+++ b/ravenloft/tests/api_requests/quests/test_get_quests.py
@@ -1,0 +1,13 @@
+import pytest
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.quest_factory import QuestFactory
+
+
+@pytest.mark.django_db
+def test_get_all_quests():
+    QuestFactory.create_batch(size=2)
+    client = APIClient()
+    response = client.get("/quests/")
+
+    assert response.status_code == 200
+    assert len(response.data) == 2

--- a/ravenloft/tests/api_requests/quests/test_update_quest.py
+++ b/ravenloft/tests/api_requests/quests/test_update_quest.py
@@ -1,0 +1,96 @@
+import pytest
+from django.utils import dateparse
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.quest_factory import QuestFactory
+
+
+@pytest.mark.django_db
+def test_update_quest():
+    quest = QuestFactory(name="Haunted Hotel", notes="")
+    client = APIClient()
+    body = {
+        "name": "Ghost Hunt",
+        "notes": "Lots of ghosts"
+    }
+    original_updated_at = quest.updated_at
+    response = client.patch(f"/quests/{quest.id}/", body)
+    updated_at = dateparse.parse_datetime(response.data["updated_at"])
+
+    assert response.status_code == 200
+    assert response.data["name"] == "Ghost Hunt"
+    assert response.data["notes"] == "Lots of ghosts"
+    assert updated_at > original_updated_at
+
+
+@pytest.mark.django_db
+def test_invalid_status():
+    quest = QuestFactory()
+    client = APIClient()
+    body = {"status": "Scooby-Doo"}
+    response = client.patch(f"/quests/{quest.id}/", body)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "status"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == '"Scooby-Doo" is not a valid choice.'
+
+
+@pytest.mark.django_db
+def test_valid_status():
+    quest = QuestFactory()
+    client = APIClient()
+    body = {"status": "Paused"}
+    response = client.patch(f"/quests/{quest.id}/", body)
+
+    assert response.status_code == 200
+    assert response.data["status"] == "Paused"
+
+
+@pytest.mark.django_db
+def test_invalid_quest_id():
+    client = APIClient()
+    response = client.patch("/quests/0/")
+
+    assert response.status_code == 404
+    assert response.data["title"] == "Not Found"
+
+    error = response.data["errors"][0]
+    assert error["detail"] == "No Quest matches the given query."
+
+
+@pytest.mark.django_db
+def test_invalid_day_completed():
+    quest = QuestFactory(day_given=5, day_completed=7)
+    client = APIClient()
+    body = {"day_completed": 3}
+    response = client.patch(f"/quests/{quest.id}/", body)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "day_completed"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == "day_completed cannot be before day_given."
+
+
+@pytest.mark.django_db
+def test_invalid_day_given():
+    quest = QuestFactory(day_given=5, day_completed=7)
+    client = APIClient()
+    body = {"day_given": 10}
+    response = client.patch(f"/quests/{quest.id}/", body)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "day_given"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == "day_given cannot be after day_completed."

--- a/ravenloft/urls.py
+++ b/ravenloft/urls.py
@@ -4,4 +4,6 @@ from ravenloft import views
 urlpatterns = [
     path("domains/", views.DomainList.as_view()),
     path("domains/<int:pk>/", views.DomainDetail.as_view()),
+    path("quests/", views.QuestList.as_view()),
+    path("quests/<int:pk>/", views.QuestDetail.as_view()),
 ]

--- a/ravenloft/views.py
+++ b/ravenloft/views.py
@@ -1,6 +1,6 @@
 from rest_framework import generics
-from .models import Domain
-from .serializers import DomainSerializer
+from .models import Domain, Quest
+from .serializers import DomainSerializer, QuestSerializer
 
 
 class DomainList(generics.ListCreateAPIView):
@@ -11,3 +11,13 @@ class DomainList(generics.ListCreateAPIView):
 class DomainDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Domain.objects.all()
     serializer_class = DomainSerializer
+
+
+class QuestList(generics.ListCreateAPIView):
+    queryset = Quest.objects.all()
+    serializer_class = QuestSerializer
+
+
+class QuestDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Quest.objects.all()
+    serializer_class = QuestSerializer


### PR DESCRIPTION
Basic CRUD for Quest model. 

Endpoints
```http
POST /quests
GET /quests
GET /quests/{quest.id}
PATCH /quests/{quest.id}
PUT /quests/{quest.id}
DELETE /quests/{quest.id}
```

**Serializer**
`DisplayChoiceField` class allows a model field's IntegerChoices to send and accept the more readable labels rather than the integer stored in the database.
Field validations added to `day_completed` and `day_given` for friendlier error responses resulting from the constraint violation.

closes #20 