### PR TITLE
NPC api

### DIFF
--- a/ravenloft/serializers.py
+++ b/ravenloft/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from ravenloft.models import Domain, Quest
+from ravenloft.models import (Domain, LivingStatus, Npc, PartyRelationship, Quest)
 
 
 class DisplayChoiceField(serializers.ChoiceField):
@@ -29,6 +29,27 @@ class DomainSerializer(serializers.ModelSerializer):
         ]
 
 
+class NpcSerializer(serializers.ModelSerializer):
+    living_status = DisplayChoiceField(choices=LivingStatus.choices, required=False)
+    relationship_to_party = DisplayChoiceField(
+        choices=PartyRelationship.choices,
+        required=False
+    )
+
+    class Meta:
+        model = Npc
+        fields = [
+            "id",
+            "name",
+            "appearance",
+            "living_status",
+            "relationship_to_party",
+            "notes",
+            "created_at",
+            "updated_at"
+        ]
+
+
 class QuestSerializer(serializers.ModelSerializer):
     status = DisplayChoiceField(choices=Quest.Status.choices, required=False)
 
@@ -37,7 +58,6 @@ class QuestSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "name",
-            "created_at",
             "day_completed",
             "day_given",
             "given_by",
@@ -46,6 +66,7 @@ class QuestSerializer(serializers.ModelSerializer):
             "reward",
             "status",
             "time_sensitive",
+            "created_at",
             "updated_at"
         ]
 

--- a/ravenloft/tests/api_requests/npcs/test_create_npc.py
+++ b/ravenloft/tests/api_requests/npcs/test_create_npc.py
@@ -1,0 +1,139 @@
+import pytest
+from rest_framework.test import APIClient
+pytestmark = pytest.mark.django_db
+
+
+def test_create_npc():
+    client = APIClient()
+    url = "/npcs/"
+    data = {
+        "name": "Aria",
+        "appearance": "Mid-30's half-elf woman in commoner clothes",
+        "living_status": "Unknown",
+        "relationship_to_party": "Friendly",
+        "notes": "Met in Neufurchtenburg"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["id"] is not None
+    assert response.data["name"] == data["name"]
+    assert response.data["appearance"] == data["appearance"]
+    assert response.data["living_status"] == data["living_status"]
+    assert response.data["relationship_to_party"] == data["relationship_to_party"]
+    assert response.data["notes"] == data["notes"]
+    assert response.data["created_at"] is not None
+    assert response.data["updated_at"] is not None
+
+
+def test_default_values():
+    client = APIClient()
+    url = "/npcs/"
+    data = {"name": "Aria"}
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["appearance"] == ""
+    assert response.data["living_status"] == "Alive"
+    assert response.data["relationship_to_party"] == "Neutral"
+    assert response.data["notes"] == ""
+
+
+def test_required_data():
+    """
+    Required fields: name
+    """
+    client = APIClient()
+    url = "/npcs/"
+    data = {}
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    errors = response.data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "name"
+
+    error_detail = errors[0]["field_errors"][0]["detail"]
+    assert error_detail == "This field is required."
+
+
+def test_invalid_name_length():
+    client = APIClient()
+    url = "/npcs/"
+    data = {"name": "A" * 61}
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "name"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == "Ensure this field has no more than 60 characters."
+
+
+def test_invalid_living_status():
+    client = APIClient()
+    url = "/npcs/"
+    data = {
+        "name": "Aria",
+        "living_status": "Invalid Status"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "living_status"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == '"Invalid Status" is not a valid choice.'
+
+
+def test_valid_living_status():
+    client = APIClient()
+    url = "/npcs/"
+    data = {
+        "name": "Aria",
+        "living_status": "Dead"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["living_status"] == "Dead"
+
+
+def test_invalid_relationship_to_party():
+    client = APIClient()
+    url = "/npcs/"
+    data = {
+        "name": "Aria",
+        "relationship_to_party": "Invalid Option"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "relationship_to_party"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == '"Invalid Option" is not a valid choice.'
+
+
+def test_valid_relationship_to_party():
+    client = APIClient()
+    url = "/npcs/"
+    data = {
+        "name": "Aria",
+        "relationship_to_party": "Adversarial"
+    }
+    response = client.post(url, data)
+
+    assert response.status_code == 201
+    assert response.data["relationship_to_party"] == "Adversarial"

--- a/ravenloft/tests/api_requests/npcs/test_delete_npc.py
+++ b/ravenloft/tests/api_requests/npcs/test_delete_npc.py
@@ -1,0 +1,23 @@
+import pytest
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.npc_factory import NpcFactory
+pytestmark = pytest.mark.django_db
+
+
+def test_delete_npc():
+    npc = NpcFactory()
+    client = APIClient()
+    response = client.delete(f"/npcs/{npc.id}/")
+
+    assert response.status_code == 204
+
+
+def test_invalid_npc_id():
+    client = APIClient()
+    response = client.get("/npcs/0/")
+
+    assert response.status_code == 404
+    assert response.data["title"] == "Not Found"
+
+    error = response.data["errors"][0]
+    assert error["detail"] == "No Npc matches the given query."

--- a/ravenloft/tests/api_requests/npcs/test_get_npc.py
+++ b/ravenloft/tests/api_requests/npcs/test_get_npc.py
@@ -1,0 +1,36 @@
+import pytest
+from django.utils import dateparse
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.npc_factory import NpcFactory
+pytestmark = pytest.mark.django_db
+
+
+def test_get_npc():
+    npc = NpcFactory()
+    client = APIClient()
+    response = client.get(f"/npcs/{npc.id}/")
+
+    created_at = dateparse.parse_datetime(response.data["created_at"])
+    updated_at = dateparse.parse_datetime(response.data["updated_at"])
+    relationship_to_party = response.data["relationship_to_party"]
+
+    assert response.status_code == 200
+    assert response.data["id"] == npc.id
+    assert response.data["name"] == npc.name
+    assert response.data["appearance"] == npc.appearance
+    assert response.data["living_status"] == npc.get_living_status_display()
+    assert relationship_to_party == npc.get_relationship_to_party_display()
+    assert response.data["notes"] == npc.notes
+    assert created_at == npc.created_at
+    assert updated_at == npc.updated_at
+
+
+def test_invalid_npc_id():
+    client = APIClient()
+    response = client.get("/npcs/0/")
+
+    assert response.status_code == 404
+    assert response.data["title"] == "Not Found"
+
+    error = response.data["errors"][0]
+    assert error["detail"] == "No Npc matches the given query."

--- a/ravenloft/tests/api_requests/npcs/test_get_npcs.py
+++ b/ravenloft/tests/api_requests/npcs/test_get_npcs.py
@@ -1,0 +1,13 @@
+import pytest
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.npc_factory import NpcFactory
+
+
+@pytest.mark.django_db
+def test_get_all_npcs():
+    NpcFactory.create_batch(size=2)
+    client = APIClient()
+    response = client.get("/npcs/")
+
+    assert response.status_code == 200
+    assert len(response.data) == 2

--- a/ravenloft/tests/api_requests/npcs/test_update_npc.py
+++ b/ravenloft/tests/api_requests/npcs/test_update_npc.py
@@ -1,0 +1,92 @@
+import pytest
+from django.utils import dateparse
+from rest_framework.test import APIClient
+from ravenloft.tests.factories.npc_factory import NpcFactory
+pytestmark = pytest.mark.django_db
+
+
+def test_update_npc():
+    npc = NpcFactory(
+        living_status=1,            # Alive
+        relationship_to_party=2     # Neutral
+    )
+    client = APIClient()
+    body = {
+        "name": "Updated Name",
+        "appearance": "Updated Appearance",
+        "living_status": "Unknown",
+        "relationship_to_party": "Uncertain",
+        "notes": "Updated Notes"
+    }
+    response = client.patch(f"/npcs/{npc.id}/", body)
+
+    original_updated_at = npc.updated_at
+    updated_at = dateparse.parse_datetime(response.data["updated_at"])
+
+    assert response.status_code == 200
+    assert response.data["id"] == npc.id
+    assert response.data["name"] == "Updated Name"
+    assert response.data["appearance"] == "Updated Appearance"
+    assert response.data["living_status"] == "Unknown"
+    assert response.data["relationship_to_party"] == "Uncertain"
+    assert response.data["notes"] == "Updated Notes"
+    assert updated_at > original_updated_at
+
+
+def test_invalid_npc_id():
+    client = APIClient()
+    response = client.patch("/npcs/0/")
+
+    assert response.status_code == 404
+    assert response.data["title"] == "Not Found"
+
+    error = response.data["errors"][0]
+    assert error["detail"] == "No Npc matches the given query."
+
+
+def test_invalid_name_length():
+    npc = NpcFactory(name="Aria")
+    client = APIClient()
+    body = {"name": "A" * 61}
+    response = client.patch(f"/npcs/{npc.id}/", body)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "name"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == "Ensure this field has no more than 60 characters."
+
+
+def test_invalid_living_status():
+    npc = NpcFactory()
+    client = APIClient()
+    body = {"living_status": "Invalid Status"}
+    response = client.patch(f"/npcs/{npc.id}/", body)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "living_status"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == '"Invalid Status" is not a valid choice.'
+
+
+def test_invalid_relationship_to_party():
+    npc = NpcFactory()
+    client = APIClient()
+    body = {"relationship_to_party": "Invalid Option"}
+    response = client.patch(f"/npcs/{npc.id}/", body)
+
+    assert response.status_code == 400
+    assert response.data["title"] == "Validation Error"
+
+    error = response.data["errors"][0]
+    assert error["field"] == "relationship_to_party"
+
+    error_detail = error["field_errors"][0]["detail"]
+    assert error_detail == '"Invalid Option" is not a valid choice.'

--- a/ravenloft/urls.py
+++ b/ravenloft/urls.py
@@ -4,6 +4,8 @@ from ravenloft import views
 urlpatterns = [
     path("domains/", views.DomainList.as_view()),
     path("domains/<int:pk>/", views.DomainDetail.as_view()),
+    path("npcs/", views.NpcList.as_view()),
+    path("npcs/<int:pk>/", views.NpcDetail.as_view()),
     path("quests/", views.QuestList.as_view()),
     path("quests/<int:pk>/", views.QuestDetail.as_view()),
 ]

--- a/ravenloft/views.py
+++ b/ravenloft/views.py
@@ -1,6 +1,6 @@
 from rest_framework import generics
-from .models import Domain, Quest
-from .serializers import DomainSerializer, QuestSerializer
+from .models import Domain, Npc, Quest
+from .serializers import DomainSerializer, NpcSerializer, QuestSerializer
 
 
 class DomainList(generics.ListCreateAPIView):
@@ -11,6 +11,16 @@ class DomainList(generics.ListCreateAPIView):
 class DomainDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Domain.objects.all()
     serializer_class = DomainSerializer
+
+
+class NpcList(generics.ListCreateAPIView):
+    queryset = Npc.objects.all()
+    serializer_class = NpcSerializer
+
+
+class NpcDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Npc.objects.all()
+    serializer_class = NpcSerializer
 
 
 class QuestList(generics.ListCreateAPIView):


### PR DESCRIPTION
Basic CRUD for NPC model. Model's integer choices accepted/returned as human readable labels.


Endpoints
```http
POST /npcs/
GET /npcs/
GET /npcs/{npc.id}/
PATCH /npcs/{npc.id}/
PUT /npcs/{npc.id}/
DELETE /npcs/{npc.id}/
```

closes #21 